### PR TITLE
Exclude db/schema.rb file from the style check.

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -80,3 +80,7 @@ Metrics/LineLength:
     - https
 
 ##################### Rails ##################################
+
+AllCops:
+  Exclude:
+    - db/schema.rb


### PR DESCRIPTION
It is a generic file and should be skipped.
