### PR TITLE
Exclude blocks format checking from spec directory

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -93,3 +93,7 @@ AllCops:
   Exclude:
     - db/schema.rb
     - bin/**
+
+Style/Blocks:
+  Exclude:
+    - "spec/**/*"


### PR DESCRIPTION
Multiline blocks should use do/end, but such structure was treated
as error, and it's a common practice in specs:

expect {
  new_organization.save_and_set_user_as_owner(user)
}.to_not change { Organization.count }

Now Style/Blocks is excluded from spec directory.
