### PR TITLE
Bump rubocop dependency to 0.35.0

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -4,9 +4,6 @@ Style/AlignParameters:
 Style/ClassAndModuleChildren:
   Enabled: false
 
-Style/Documentation:
-  Enabled: false
-
 # Multi-line method chaining should be done with leading dots.
 Style/DotPosition:
   EnforcedStyle: trailing
@@ -94,6 +91,6 @@ AllCops:
     - db/schema.rb
     - bin/**
 
-Style/Blocks:
+Style/BlockDelimiters:
   Exclude:
     - "spec/**/*"

--- a/ragnarson-stylecheck.gemspec
+++ b/ragnarson-stylecheck.gemspec
@@ -10,5 +10,5 @@ Gem::Specification.new do |s|
   s.homepage      = "https://github.com/ragnarson/ragnarson-stylecheck"
   s.license       = "MIT"
 
-  s.add_dependency "rubocop", "~> 0.29.1"
+  s.add_dependency "rubocop", "~> 0.35.0"
 end


### PR DESCRIPTION
- rename `Style/Blocks` cop to `Style/BlockDelimiters` according to the
  https://github.com/bbatsov/rubocop/commit/ad470057d91158223498688298cfdb2a21fe50f8
- `Style/Documentation` cop is now disabled by default according to the https://github.com/bbatsov/rubocop/issues/2260

I need to use `inherit_gem` feature to override some cops. https://github.com/bbatsov/rubocop/issues/2367.
