### PR TITLE
Use symmetrical hash layout

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -23,7 +23,7 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 
 Style/MultilineHashBraceLayout:
-  EnforcedStyle: same_line
+  EnforcedStyle: symmetrical
 
 Style/MultilineMethodCallIndentation:
   EnforcedStyle: indented


### PR DESCRIPTION
http://www.rubydoc.info/gems/rubocop/0.42.0/RuboCop/Cop/Style/MultilineHashBraceLayout

```
# symmetrical: bad
# new_line: good
# same_line: bad
{ a: 1,
  b: 2
}

# symmetrical: bad
# new_line: bad
# same_line: good
{
  a: 1,
  b: 2 }

# symmetrical: good
# new_line: bad
# same_line: good
{ a: 1,
  b: 2 }

# symmetrical: good
# new_line: good
# same_line: bad
{
  a: 1,
  b: 2
}
```