### PR TITLE
Move `rake` gem to runtime dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     ragnarson-stylecheck (0.2.2)
+      rake (~> 10.0)
       rubocop (~> 0.42.0)
 
 GEM
@@ -28,7 +29,6 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.10)
   ragnarson-stylecheck!
-  rake (~> 10.0)
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ragnarson-stylecheck (0.2.2)
       rake (~> 10.0)
-      rubocop (~> 0.42.0)
+      rubocop (~> 0.47)
 
 GEM
   remote: https://rubygems.org/
@@ -14,8 +14,8 @@ GEM
     powerpack (0.1.1)
     rainbow (2.2.1)
     rake (10.5.0)
-    rubocop (0.42.0)
-      parser (>= 2.3.1.1, < 3.0)
+    rubocop (0.47.1)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)

--- a/ragnarson-stylecheck.gemspec
+++ b/ragnarson-stylecheck.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |s|
   s.license       = "MIT"
 
   s.add_development_dependency "bundler", "~> 1.10"
-  s.add_development_dependency "rake", "~> 10.0"
+  s.add_dependency "rake", "~> 10.0"
   s.add_dependency "rubocop", "~> 0.47"
 end

--- a/ragnarson-stylecheck.gemspec
+++ b/ragnarson-stylecheck.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.summary       = "Automatic style check for ragnarson projects"
   s.description   = "Wraps rubocop for simple and consisten experience"
   s.authors       = ["Grzesiek Kołodziejczyk", "Maciej Małecki", "Oskar Szrajer", "Piotr Marciniak"]
-  s.email         = "oskarszrajer@gmail.com"
+  s.email         = "hello@ragnarson.com"
   s.files         = Dir["{config,lib}/**/*", "MIT-LICENSE", "README.md", "./"]
   s.homepage      = "https://github.com/ragnarson/ragnarson-stylecheck"
   s.license       = "MIT"


### PR DESCRIPTION
`rake` is required to run a `style` task, but it's not always available in non-rails projects.