### PR TITLE
Loosen rubocop dependency, bump it to 0.47

### DIFF
--- a/ragnarson-stylecheck.gemspec
+++ b/ragnarson-stylecheck.gemspec
@@ -12,5 +12,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "bundler", "~> 1.10"
   s.add_development_dependency "rake", "~> 10.0"
-  s.add_dependency "rubocop", "~> 0.42.0"
+  s.add_dependency "rubocop", "~> 0.47"
 end


### PR DESCRIPTION
I don't see a reason why should stick with hard dependency on minor
rubocop version.