### PR TITLE
Rubocop CVE-2017-8418, bump version to 0.49

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,25 +3,28 @@ PATH
   specs:
     ragnarson-stylecheck (0.3.0)
       rake (~> 10.0)
-      rubocop (~> 0.47)
+      rubocop (~> 0.49)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.3.0)
+    parallel (1.11.2)
     parser (2.4.0.0)
       ast (~> 2.2)
     powerpack (0.1.1)
-    rainbow (2.2.1)
+    rainbow (2.2.2)
+      rake
     rake (10.5.0)
-    rubocop (0.47.1)
+    rubocop (0.49.1)
+      parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    unicode-display_width (1.1.3)
+    unicode-display_width (1.2.1)
 
 PLATFORMS
   ruby

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,45 +1,65 @@
 AllCops:
   TargetRubyVersion: 2.3
 
-Style/AlignHash:
+##################### Layout ##################################
+
+Layout/AlignHash:
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table
 
-Style/ClassAndModuleChildren:
-  Enabled: false
-
 # Multi-line method chaining should be done with leading dots.
-Style/DotPosition:
+Layout/DotPosition:
   EnforcedStyle: trailing
 
 # Use empty lines between defs.
-Style/EmptyLineBetweenDefs:
+Layout/EmptyLineBetweenDefs:
   # If true, this parameter means that single line method definitions don't
   # need an empty line between them.
   AllowAdjacentOneLineDefs: true
 
-Style/EmptyLines:
+Layout/EmptyLines:
   Exclude:
     - Gemfile
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Style/MultilineHashBraceLayout:
+Layout/MultilineHashBraceLayout:
   EnforcedStyle: symmetrical
 
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
+
+##################### Lint ##################################
+
+# Allow logical `or`/`and` in conditionals
+
+Lint/AssignmentInCondition:
+  Enabled: false
+
+##################### Style ##################################
+
+Style/AndOr:
+  EnforcedStyle: conditionals
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
 
 # Enforce the method used for string formatting.
 Style/FormatString:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/IfUnlessModifier:
   MaxLineLength: 120
+
+Style/RaiseArgs:
+  Enabled: false
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
@@ -53,24 +73,14 @@ Style/StringLiteralsInInterpolation:
 Style/TrailingCommaInLiteral:
   Enabled: false
 
-Style/RaiseArgs:
-  Enabled: false
-
-# Allow logical `or`/`and` in conditionals
-Style/AndOr:
-  EnforcedStyle: conditionals
-
-Lint/AssignmentInCondition:
-  Enabled: false
-
-Style/Documentation:
-  Enabled: false
-
 ##################### Metrics ##################################
 
 Metrics/AbcSize:
   Severity: warning
   Max: 25
+
+Metrics/BlockLength:
+  Max: 30
 
 Metrics/LineLength:
   Max: 120

--- a/ragnarson-stylecheck.gemspec
+++ b/ragnarson-stylecheck.gemspec
@@ -12,5 +12,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "bundler", "~> 1.10"
   s.add_dependency "rake", "~> 10.0"
-  s.add_dependency "rubocop", "~> 0.47"
+  s.add_dependency "rubocop", "~> 0.49"
 end


### PR DESCRIPTION
- There was a [CVE in rubocop](https://nvd.nist.gov/vuln/detail/CVE-2017-8418). It is low severity but
some vulnerability scanners may detect this as an issue.
- New layout deparment [was introduced with 0.49](bbatsov/rubocop#4278), adjust rubocop.yml. 
- Fix failing BlockSize cop.