### PR TITLE
Update style rules

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -73,6 +73,21 @@ Style/StringLiteralsInInterpolation:
 Style/TrailingCommaInLiteral:
   Enabled: false
 
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    "%":  ()
+    "%i": ()
+    "%q": ()
+    "%Q": ()
+    "%r": "{}"
+    "%s": ()
+    "%w": ()
+    "%W": ()
+    "%x": ()
+
+Style/FormatStringToken:
+  EnforcedStyle: template
+
 ##################### Metrics ##################################
 
 Metrics/AbcSize:
@@ -98,6 +113,7 @@ Metrics/ParameterLists:
 ##################### Rails ##################################
 
 AllCops:
+  DisplayCopNames: true
   Exclude:
     - db/schema.rb
     - bin/**
@@ -106,3 +122,13 @@ AllCops:
 Style/BlockDelimiters:
   Exclude:
     - "spec/**/*"
+
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*.rb"
+    - "config/**/*.rb"
+
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*.rb"
+    - "config/**/*.rb"


### PR DESCRIPTION
Changed rules:
- [Style/PercentLiteralDelimiters](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/PercentLiteralDelimiters)
- [Style/FormatStringToken](http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/FormatStringToken)
- [Metrics/BlockLength](http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Metrics/BlockLength)
- [Lint/AmbiguousBlockAssociation](http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Lint/AmbiguousBlockAssociation)