### PR TITLE
Fix for obsolete parameter error and new ruby target version.

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
 
 ##################### Layout ##################################
 
@@ -57,9 +57,6 @@ Style/FormatString:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
-
-Style/IfUnlessModifier:
-  MaxLineLength: 120
 
 Style/RaiseArgs:
   Enabled: false

--- a/lib/ragnarson/templates/rubocop.yml
+++ b/lib/ragnarson/templates/rubocop.yml
@@ -2,4 +2,4 @@ inherit_gem:
   ragnarson-stylecheck: config/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5

--- a/ragnarson-stylecheck.gemspec
+++ b/ragnarson-stylecheck.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = "ragnarson-stylecheck"
-  s.version       = "0.6.0"
+  s.version       = "0.6.1"
   s.summary       = "Automatic style check for ragnarson projects"
   s.description   = "Wraps rubocop for simple and consisten experience"
   s.authors       = ["Grzesiek Kołodziejczyk", "Maciej Małecki", "Oskar Szrajer", "Piotr Marciniak"]


### PR DESCRIPTION
- `Style/IfUnlessModifier: MaxLineLength: has been removed` in ` config/rubocop.yml ` has been fixed
- New ruby target version is set to ` 2.5 ` 